### PR TITLE
Add Octopus Bot (#1)

### DIFF
--- a/.github/scripts/audit.sh
+++ b/.github/scripts/audit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Current repo substrate version"
+current_dependencies="$(awk '/build-dependencies/{print;getline;print}' runtime/Cargo.toml)"
+echo $current_dependencies
+
+echo "Barnacle repo substrate version"
+barnacle_dependencies="$(curl -s https://raw.githubusercontent.com/octopus-network/barnacle/master/runtime/Cargo.toml | \
+  awk '/build-dependencies/{print;getline;print}')"
+echo $barnacle_dependencies
+
+if [ "$current_dependencies" == "$barnacle_dependencies" ]; then
+    echo "Success, they are same."
+else
+    echo "Failed, please check, the current substrate dependencies is different from barnacle."
+    exit 125
+fi

--- a/.github/workflows/octopus-audit-auto.yml
+++ b/.github/workflows/octopus-audit-auto.yml
@@ -1,0 +1,14 @@
+name: Octopus Bot
+on: [push]
+jobs:
+  Octopus-Audit-Auto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Check the barnacle version
+        run: |
+          chmod +x "${GITHUB_WORKSPACE}/.github/scripts/audit.sh"
+          "${GITHUB_WORKSPACE}/.github/scripts/audit.sh"
+      - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
Can we add a CI bot to help us check the version of packages, Naming conventions, etc? 

For example, Audit
- check the version of substrate between barnacle and forked appchain.

If the version is different between barnacle and forked one, then CI will be failed, see as below screenshot.

![图片](https://user-images.githubusercontent.com/10057052/157580891-bbfab1d9-76a6-461b-ade1-b820d6d62529.png)

Can you guys help review this and give some suggestions, thanks! @en @lesterli
