### PR TITLE
Add precompiles to support cross chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,8 @@ dependencies = [
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
+ "pallet-evm-precompile-octopus-appchain",
+ "pallet-evm-precompile-octopus-session",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
  "pallet-grandpa",
@@ -4858,6 +4860,74 @@ source = "git+https://github.com/PureStake/frontier.git?branch=moonbeam-polkadot
 dependencies = [
  "fp-evm",
  "num",
+]
+
+[[package]]
+name = "pallet-evm-precompile-octopus-appchain"
+version = "0.1.0"
+dependencies = [
+ "account",
+ "derive_more",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "hex-literal",
+ "libsecp256k1 0.7.0",
+ "log",
+ "num_enum",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-octopus-appchain",
+ "pallet-octopus-lpos",
+ "pallet-octopus-upward-messages",
+ "pallet-session",
+ "pallet-timestamp",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "precompile-utils",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-evm-precompile-octopus-session"
+version = "0.1.0"
+dependencies = [
+ "account",
+ "derive_more",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "hex-literal",
+ "libsecp256k1 0.7.0",
+ "log",
+ "num_enum",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-octopus-appchain",
+ "pallet-octopus-lpos",
+ "pallet-octopus-upward-messages",
+ "pallet-session",
+ "pallet-timestamp",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "precompile-utils",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
 ]
 
 [[package]]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -3,7 +3,7 @@ use appchain_barnacle_runtime::{
 	opaque::{Block, SessionKeys},
 	AccountId, BabeConfig, Balance, BalancesConfig, GenesisAccount, GenesisConfig, GrandpaConfig,
 	ImOnlineConfig, OctopusAppchainConfig, OctopusLposConfig, Precompiles, SessionConfig,
-	Signature, SudoConfig, SystemConfig, WASM_BINARY,
+	SudoConfig, SystemConfig, WASM_BINARY,
 };
 use beefy_primitives::crypto::AuthorityId as BeefyId;
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
@@ -12,13 +12,11 @@ use sc_chain_spec::ChainSpecExtension;
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
 use sp_consensus_babe::AuthorityId as BabeId;
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
-use sp_runtime::traits::{IdentifyAccount, Verify};
 
 use appchain_barnacle_runtime::{EVMConfig, EthereumConfig};
-use sp_core::{H160, U256};
-use std::{collections::BTreeMap, str::FromStr};
+use std::str::FromStr;
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";

--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.4.24;
 
 /**
@@ -130,7 +131,7 @@ interface WrappedNativeCurrency {
    * @dev Provide compatibility for contracts that expect wETH design.
    * Does nothing.
    * Selector: 2e1a7d4d
-   * @param Amount to withdraw/unwrap.
+   * @param value to withdraw/unwrap.
    */
   function withdraw(uint256 value) external;
 

--- a/precompiles/octopus-appchain/Cargo.toml
+++ b/precompiles/octopus-appchain/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+name = "pallet-evm-precompile-octopus-appchain"
+authors = ["Octopus Network <hi@oct.network>"]
+description = "A Precompile to make pallet-octopus-appchain accessible to pallet-evm"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+log = "0.4"
+num_enum = { version = "0.5.3", default-features = false }
+
+# Moonbeam
+precompile-utils = { path = "../utils", default-features = false }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
+# Frontier
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
+# Octopus
+pallet-octopus-appchain = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
+
+[dev-dependencies]
+derive_more = { version = "0.99" }
+hex-literal = "0.3.4"
+libsecp256k1 = "0.7"
+serde = { version = "1.0.100" }
+sha3 = "0.8"
+
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
+scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
+
+sp-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+pallet-assets = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+pallet-session = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18", features = ["historical"] }
+pallet-uniques = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+
+pallet-octopus-lpos = { git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
+pallet-octopus-upward-messages = { git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
+account = { path = "../../primitives/account/" }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"fp-evm/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-evm/std",
+	"precompile-utils/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-std/std",
+	"pallet-octopus-appchain/std",
+]

--- a/precompiles/octopus-appchain/OctopusAppchainInterface.sol
+++ b/precompiles/octopus-appchain/OctopusAppchainInterface.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.8.0 <0.9.0;
+
+/**
+ * @title Pallet OctopusAppchain Interface
+ *
+ * The interface through which solidity contracts will interact with pallet-octopus-appchain
+ * Address :    0x0000000000000000000000000000000000000803
+ */
+
+interface OctopusAppchain {
+    /**
+	 * lock native token 
+     * Selector: 0xd8f7c836 
+	 *
+	 * @param receiver_id The receiver address in near
+	 * @param amount The amount to cross 
+	 *
+     */
+    function lock(uint256 amount, bytes memory receiver_id) external;
+
+
+    /**
+	 * burn asset
+     * Selector: 0xe1a6d74c
+	 *
+	 * @param receiver_id The receiver address in near
+	 * @param amount The amount to cross 
+	 * @param asset_id The id of asset to cross 
+	 *
+     */
+    function burn_asset(uint32 asset_id, uint128 amount, bytes memory receiver_id) external;
+
+
+    /**
+	 * lock nft 
+     * Selector: 0x6ad31c32 
+	 *
+	 * @param receiver_id The receiver address in near
+	 * @param instance The instance id of nft 
+	 * @param class The class id of nft 
+	 *
+     */
+    function lock_nft(uint128 class, uint128 instance, bytes memory receiver_id) external;
+}

--- a/precompiles/octopus-appchain/src/lib.rs
+++ b/precompiles/octopus-appchain/src/lib.rs
@@ -1,0 +1,191 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use fp_evm::{Context, ExitSucceed, PrecompileOutput};
+use frame_support::{
+	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+	traits::Currency,
+};
+use pallet_evm::{AddressMapping, Precompile};
+use pallet_octopus_appchain::Call as OctopusAppchainCall;
+use precompile_utils::{
+	Bytes, EvmData, EvmDataReader, EvmResult, FunctionModifier, Gasometer, RuntimeHelper,
+};
+use sp_core::H256;
+use sp_std::{fmt::Debug, marker::PhantomData};
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+type BalanceOf<Runtime> = <<Runtime as pallet_octopus_appchain::Config>::Currency as Currency<
+	<Runtime as frame_system::Config>::AccountId,
+>>::Balance;
+
+#[precompile_utils::generate_function_selector]
+#[derive(Debug, PartialEq)]
+pub enum Action {
+	Lock = "lock(uint256,bytes)",
+	BurnAsset = "burn_asset(uint32,uint128,bytes)",
+	LockNft = "lock_nft(uint128,uint128,bytes)",
+}
+
+/// A precompile to wrap the functionality from pallet octopus-appchain.
+pub struct OctopusAppchainWrapper<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> Precompile for OctopusAppchainWrapper<Runtime>
+where
+	Runtime: pallet_octopus_appchain::Config + pallet_evm::Config + frame_system::Config,
+	<Runtime as frame_system::Config>::Call:
+		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin:
+		From<Option<Runtime::AccountId>>,
+	<Runtime as frame_system::Config>::Call: From<OctopusAppchainCall<Runtime>>,
+	Runtime::Hash: From<H256>,
+	BalanceOf<Runtime>: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::AssetId: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::AssetBalance: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::ClassId: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::InstanceId: EvmData,
+{
+	fn execute(
+		input: &[u8], //Reminder this is big-endian
+		target_gas: Option<u64>,
+		context: &Context,
+		is_static: bool,
+	) -> EvmResult<PrecompileOutput> {
+		log::trace!(target: "octopus-appchain-precompile", "In octopus-appchain wrapper");
+
+		let mut gasometer = Gasometer::new(target_gas);
+		let gasometer = &mut gasometer;
+
+		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
+		let input = &mut input;
+
+		gasometer.check_function_modifier(context, is_static, FunctionModifier::NonPayable)?;
+
+		match selector {
+			// Dispatchables
+			Action::Lock => Self::lock(input, gasometer, context),
+			Action::BurnAsset => Self::burn_asset(input, gasometer, context),
+			Action::LockNft => Self::lock_nft(input, gasometer, context),
+		}
+	}
+}
+
+impl<Runtime> OctopusAppchainWrapper<Runtime>
+where
+	Runtime: pallet_octopus_appchain::Config + pallet_evm::Config + frame_system::Config,
+	<Runtime as frame_system::Config>::Call:
+		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin:
+		From<Option<Runtime::AccountId>>,
+	<Runtime as frame_system::Config>::Call: From<OctopusAppchainCall<Runtime>>,
+	Runtime::Hash: From<H256>,
+	BalanceOf<Runtime>: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::AssetId: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::AssetBalance: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::ClassId: EvmData,
+	<Runtime as pallet_octopus_appchain::Config>::InstanceId: EvmData,
+{
+	// The dispatchable wrappers are next. They dispatch a Substrate inner Call.
+	fn lock(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		context: &Context,
+	) -> EvmResult<PrecompileOutput> {
+		// Bound check
+		input.expect_arguments(gasometer, 2)?;
+
+		let amount = input.read::<BalanceOf<Runtime>>(gasometer)?;
+		let receiver_id = input.read::<Bytes>(gasometer)?;
+
+		log::trace!(
+			target: "octopus-appchain-precompile",
+			"lock in appchain, receiver_id: {:?}, amount {:?}", receiver_id, amount,
+		);
+
+		let origin = Runtime::AddressMapping::into_account_id(context.caller);
+		let call = OctopusAppchainCall::<Runtime>::lock { amount, receiver_id: receiver_id.0 };
+
+		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
+
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: Default::default(),
+			logs: Default::default(),
+		})
+	}
+
+	fn burn_asset(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		context: &Context,
+	) -> EvmResult<PrecompileOutput> {
+		// Bound check
+		input.expect_arguments(gasometer, 3)?;
+
+		let asset_id: <Runtime as pallet_octopus_appchain::Config>::AssetId =
+			input.read(gasometer)?;
+		let amount = input.read(gasometer)?;
+		let receiver_id = input.read::<Bytes>(gasometer)?;
+
+		log::trace!(
+			target: "octopus-appchain-precompile",
+			"burn asset in appchain, asset_id: {:?}, receiver_id: {:?}, amount {:?}", asset_id, receiver_id, amount,
+		);
+
+		let origin = Runtime::AddressMapping::into_account_id(context.caller);
+		let call = OctopusAppchainCall::<Runtime>::burn_asset {
+			asset_id,
+			amount,
+			receiver_id: receiver_id.0,
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
+
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: Default::default(),
+			logs: Default::default(),
+		})
+	}
+
+	fn lock_nft(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		context: &Context,
+	) -> EvmResult<PrecompileOutput> {
+		// Bound check
+		input.expect_arguments(gasometer, 3)?;
+
+		let class: <Runtime as pallet_octopus_appchain::Config>::ClassId = input.read(gasometer)?;
+		let instance: <Runtime as pallet_octopus_appchain::Config>::InstanceId =
+			input.read(gasometer)?;
+		let receiver_id = input.read::<Bytes>(gasometer)?;
+
+		log::trace!(
+			target: "octopus-appchain-precompile",
+			"lock nft in appchain, class_id: {:?}, instance_id: {:?}, receiver_id: {:?}", class, instance, receiver_id,
+		);
+
+		let origin = Runtime::AddressMapping::into_account_id(context.caller);
+		let call = OctopusAppchainCall::<Runtime>::lock_nft {
+			class,
+			instance,
+			receiver_id: receiver_id.0,
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
+
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: Default::default(),
+			logs: Default::default(),
+		})
+	}
+}

--- a/precompiles/octopus-appchain/src/mock.rs
+++ b/precompiles/octopus-appchain/src/mock.rs
@@ -1,0 +1,451 @@
+use super::*;
+use pallet_octopus_appchain::traits_default_impl::ExampleConvertor;
+use sp_runtime::{
+	generic, impl_opaque_keys,
+	testing::TestXt,
+	traits::{
+		AccountIdLookup, BlakeTwo256, ConvertInto, Extrinsic as ExtrinsicT, IdentifyAccount,
+		OpaqueKeys, Verify,
+	},
+};
+
+use pallet_evm::{EnsureAddressNever, EnsureAddressRoot, PrecompileSet};
+use sp_core::H160;
+
+pub use frame_support::{
+	construct_runtime,
+	pallet_prelude::GenesisBuild,
+	parameter_types,
+	traits::{
+		ConstU128, ConstU32, Hooks, KeyOwnerProofSystem, OnFinalize, OnInitialize, Randomness,
+		StorageInfo,
+	},
+	weights::{IdentityFee, Weight},
+	PalletId, StorageValue,
+};
+
+use account::EthereumSignature;
+use frame_system::EnsureRoot;
+
+pub(crate) type BlockNumber = u32;
+pub type Signature = EthereumSignature;
+pub type Balance = u128;
+pub type Moment = u64;
+pub type Index = u64;
+pub type Hash = sp_core::H256;
+
+pub const MILLICENTS: Balance = 10_000_000_000;
+pub const CENTS: Balance = 1_000 * MILLICENTS;
+pub const DOLLARS: Balance = 100 * CENTS;
+pub const MILLISECS_PER_BLOCK: Moment = 3000;
+pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
+pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
+pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 1 * MINUTES;
+pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
+
+parameter_types! {
+	pub const BlockHashCount: BlockNumber = 2400;
+	pub const SS58Prefix: u16 = 42;
+}
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type AccountId = AccountId;
+	type Call = Call;
+	type Lookup = AccountIdLookup<AccountId, ()>;
+	type Index = Index;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hashing = BlakeTwo256;
+	type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	type Event = Event;
+	type Origin = Origin;
+	type BlockHashCount = BlockHashCount;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: Moment = SLOT_DURATION / 2;
+}
+impl pallet_timestamp::Config for Test {
+	type Moment = Moment;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: Balance = 1 * DOLLARS;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
+}
+impl pallet_balances::Config for Test {
+	type MaxLocks = MaxLocks;
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+}
+
+// use pallet_octopus_appchain::ecdsa::AuthorityId as OctopusId;
+impl_opaque_keys! {
+	pub struct MockSessionKeys {
+		pub octopus: OctopusAppchain,
+	}
+}
+
+pub struct MockSessionManager;
+
+impl pallet_session::SessionManager<AccountId> for MockSessionManager {
+	fn end_session(_: sp_staking::SessionIndex) {}
+	fn start_session(index: sp_staking::SessionIndex) {
+		OctopusLpos::start_session(index);
+	}
+	fn new_session(_: sp_staking::SessionIndex) -> Option<Vec<AccountId>> {
+		None
+	}
+}
+
+parameter_types! {
+	pub const Period: u32 = 1;
+	pub const Offset: u32 = 0;
+}
+impl pallet_session::Config for Test {
+	type Event = Event;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
+	type ValidatorIdOf = ConvertInto;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type SessionManager = MockSessionManager;
+	type SessionHandler = <MockSessionKeys as OpaqueKeys>::KeyTypeIdProviders;
+	type Keys = MockSessionKeys;
+	type WeightInfo = pallet_session::weights::SubstrateWeight<Test>;
+}
+
+impl pallet_session::historical::Config for Test {
+	type FullIdentification = u128;
+	type FullIdentificationOf = pallet_octopus_lpos::ExposureOf<Test>;
+}
+
+pub(crate) type Extrinsic = TestXt<Call, ()>;
+pub(crate) type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+impl frame_system::offchain::SigningTypes for Test {
+	type Public = <Signature as Verify>::Signer;
+	type Signature = Signature;
+}
+
+impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
+where
+	Call: From<LocalCall>,
+{
+	type OverarchingCall = Call;
+	type Extrinsic = Extrinsic;
+}
+
+impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
+where
+	Call: From<LocalCall>,
+{
+	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+		call: Call,
+		_public: <Signature as Verify>::Signer,
+		_account: AccountId,
+		nonce: u64,
+	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+		Some((call, (nonce, ())))
+	}
+}
+
+parameter_types! {
+	pub const AssetDeposit: Balance = 100 * DOLLARS;
+	pub const ApprovalDeposit: Balance = 1 * DOLLARS;
+	pub const StringLimit: u32 = 50;
+	pub const MetadataDepositBase: Balance = 10 * DOLLARS;
+	pub const MetadataDepositPerByte: Balance = 1 * DOLLARS;
+}
+pub type AssetId = u32;
+pub type AssetBalance = u128;
+
+impl pallet_assets::Config for Test {
+	type Event = Event;
+	type Balance = AssetBalance;
+	type AssetId = AssetId;
+	type Currency = Balances;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type AssetDeposit = AssetDeposit;
+	type AssetAccountDeposit = ConstU128<DOLLARS>;
+	type MetadataDepositBase = MetadataDepositBase;
+	type MetadataDepositPerByte = MetadataDepositPerByte;
+	type ApprovalDeposit = ApprovalDeposit;
+	type StringLimit = StringLimit;
+	type Freezer = ();
+	type Extra = ();
+	type WeightInfo = pallet_assets::weights::SubstrateWeight<Test>;
+}
+
+pub struct OctopusAppCrypto;
+
+impl frame_system::offchain::AppCrypto<<Signature as Verify>::Signer, Signature>
+	for OctopusAppCrypto
+{
+	type RuntimeAppPublic = pallet_octopus_appchain::ecdsa::AuthorityId;
+	type GenericSignature = sp_core::ecdsa::Signature;
+	type GenericPublic = sp_core::ecdsa::Public;
+}
+
+parameter_types! {
+	pub const SessionsPerEra: sp_staking::SessionIndex = 6;
+	pub const BondingDuration: pallet_octopus_lpos::EraIndex = 24 * 28;
+	pub const BlocksPerEra: u32 = EPOCH_DURATION_IN_BLOCKS * 6 / (SECS_PER_BLOCK as u32);
+}
+
+impl pallet_octopus_lpos::Config for Test {
+	type Currency = Balances;
+	type UnixTime = Timestamp;
+	type Event = Event;
+	type Reward = (); // rewards are minted from the void
+	type SessionsPerEra = SessionsPerEra;
+	type BondingDuration = BondingDuration;
+	type BlocksPerEra = BlocksPerEra;
+	type SessionInterface = Self;
+	type AppchainInterface = OctopusAppchain;
+	type UpwardMessagesInterface = OctopusUpwardMessages;
+	type PalletId = OctopusAppchainPalletId;
+	type ValidatorsProvider = OctopusAppchain;
+	type WeightInfo = pallet_octopus_lpos::weights::SubstrateWeight<Test>;
+}
+
+impl pallet_octopus_upward_messages::Config for Test {
+	type Event = Event;
+	type Call = Call;
+	type UpwardMessagesLimit = UpwardMessagesLimit;
+	type WeightInfo = pallet_octopus_upward_messages::weights::SubstrateWeight<Test>;
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: frame_system,
+		Timestamp: pallet_timestamp,
+		Balances: pallet_balances,
+		OctopusAppchain: pallet_octopus_appchain,
+		// OctopusAppchain: pallet_octopus_appchain::{Pallet, Call, Storage, Config<T>, Event<T>, ValidateUnsigned},
+		OctopusLpos: pallet_octopus_lpos,
+		OctopusUpwardMessages: pallet_octopus_upward_messages,
+		Session: pallet_session,
+		Assets: pallet_assets,
+		Uniques: pallet_uniques,
+		Evm: pallet_evm,
+	}
+);
+
+type ClassId = u128;
+type InstanceId = u128;
+parameter_types! {
+	pub const ClassDeposit: Balance = 100 * DOLLARS;
+	pub const InstanceDeposit: Balance = 1 * DOLLARS;
+	pub const KeyLimit: u32 = 32;
+	pub const ValueLimit: u32 = 256;
+}
+impl pallet_uniques::Config for Test {
+	type Event = Event;
+	type ClassId = ClassId;
+	type InstanceId = InstanceId;
+	type Currency = Balances;
+	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
+	type ClassDeposit = ClassDeposit;
+	type InstanceDeposit = InstanceDeposit;
+	type MetadataDepositBase = MetadataDepositBase;
+	type AttributeDepositBase = MetadataDepositBase;
+	type DepositPerByte = MetadataDepositPerByte;
+	type StringLimit = StringLimit;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	   pub const OctopusAppchainPalletId: PalletId = PalletId(*b"py/octps");
+	   pub const GracePeriod: u32 = 10;
+	   pub const UnsignedPriority: u64 = 1 << 21;
+	   pub const RequestEventLimit: u32 = 10;
+	   pub const UpwardMessagesLimit: u32 = 10;
+}
+
+impl pallet_octopus_appchain::Config for Test {
+	type AssetId = AssetId;
+	type AssetBalance = AssetBalance;
+	type AssetIdByTokenId = OctopusAppchain;
+	type AuthorityId = pallet_octopus_appchain::ecdsa::AuthorityId;
+	type AppCrypto = OctopusAppCrypto;
+	type Event = Event;
+	type Call = Call;
+	type PalletId = OctopusAppchainPalletId;
+	type LposInterface = OctopusLpos;
+	type UpwardMessagesInterface = OctopusUpwardMessages;
+	type ClassId = ClassId;
+	type InstanceId = InstanceId;
+	type Uniques = Uniques;
+	type Convertor = ExampleConvertor<Test>;
+	type Currency = Balances;
+	type Assets = Assets;
+	type GracePeriod = GracePeriod;
+	type UnsignedPriority = UnsignedPriority;
+	type RequestEventLimit = RequestEventLimit;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const PrecompilesValue: Precompiles<Test> = Precompiles(PhantomData);
+}
+
+pub struct IntoAddressMapping;
+
+impl<T: From<H160>> pallet_evm::AddressMapping<T> for IntoAddressMapping {
+	fn into_account_id(address: H160) -> T {
+		address.into()
+	}
+}
+
+impl pallet_evm::Config for Test {
+	type FeeCalculator = ();
+	type GasWeightMapping = ();
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = IntoAddressMapping;
+	type Currency = Balances;
+	type Event = Event;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = Precompiles<Self>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ();
+	type OnChargeTransaction = ();
+	type BlockGasLimit = ();
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = ();
+	type WeightInfo = ();
+}
+
+// impl crate::Config for Test {}
+
+pub const PRECOMPILE_ADDRESS: u64 = 1;
+
+#[derive(Default)]
+pub struct Precompiles<R>(PhantomData<R>);
+
+impl<R> PrecompileSet for Precompiles<R>
+where
+	OctopusAppchainWrapper<R>: Precompile,
+{
+	fn execute(
+		&self,
+		address: H160,
+		input: &[u8],
+		target_gas: Option<u64>,
+		context: &Context,
+		is_static: bool,
+	) -> Option<EvmResult<PrecompileOutput>> {
+		match address {
+			a if a == hash(PRECOMPILE_ADDRESS) =>
+				Some(OctopusAppchainWrapper::<R>::execute(input, target_gas, context, is_static)),
+			_ => None,
+		}
+	}
+
+	fn is_precompile(&self, address: H160) -> bool {
+		address == hash(PRECOMPILE_ADDRESS)
+	}
+}
+
+fn hash(a: u64) -> H160 {
+	H160::from_low_u64_be(a)
+}
+
+// pub fn new_test_ext() -> sp_io::TestExternalities {
+// 	let stash: Balance = 100 * 1_000_000_000_000_000_000; // 100 OCT with 18 decimals
+// 	let mut storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+// 	// let initial_authorities: Vec<(AccountId, OctopusId)> =
+// 	// 	vec![authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob")];
+// 	// let validators = initial_authorities.iter().map(|x| (x.0.clone(), stash)).collect::<Vec<_>>();
+
+// 	// let keys: Vec<_> = initial_authorities
+// 	// 	.iter()
+// 	// 	.map(|x| (x.0.clone(), x.0.clone(), MockSessionKeys { octopus: x.1.clone() }))
+// 	// 	.collect::<Vec<_>>();
+
+// 	// let config: pallet_session::GenesisConfig<Test> = pallet_session::GenesisConfig { keys };
+// 	// config.assimilate_storage(&mut storage).unwrap();
+
+// 	// let config: pallet_octopus_appchain::GenesisConfig<Test> =
+// 	// 	pallet_octopus_appchain::GenesisConfig {
+// 	// 		anchor_contract: "oct-test.testnet".to_string(),
+// 	// 		validators,
+// 	// 		premined_amount: 1024 * DOLLARS,
+// 	// 		asset_id_by_token_id: vec![
+// 	// 			("test-account.testnet".to_string(), 0),
+// 	// 			("usdc.testnet".to_string(), 2),
+// 	// 		],
+// 	// 	};
+// 	// config.assimilate_storage(&mut storage).unwrap();
+
+// 	let mut ext: sp_io::TestExternalities = storage.into();
+// 	ext.execute_with(|| System::set_block_number(1));
+// 	ext
+// }
+
+pub(crate) struct ExtBuilder {
+	// endowed accounts with balances
+	balances: Vec<(AccountId, Balance)>,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> ExtBuilder {
+		ExtBuilder { balances: vec![] }
+	}
+}
+
+impl ExtBuilder {
+	pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, Balance)>) -> Self {
+		self.balances = balances;
+		self
+	}
+
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.expect("Frame system builds valid default genesis config");
+
+		pallet_balances::GenesisConfig::<Test> { balances: self.balances }
+			.assimilate_storage(&mut t)
+			.expect("Pallet balances storage can be assimilated");
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub fn precompile_address() -> H160 {
+	H160::from_low_u64_be(1)
+}

--- a/precompiles/octopus-appchain/src/tests.rs
+++ b/precompiles/octopus-appchain/src/tests.rs
@@ -1,0 +1,115 @@
+use crate::{mock::*, *};
+
+use precompile_utils::{Bytes, EvmDataWriter};
+use sp_core::U256;
+
+use frame_support::assert_ok;
+use pallet_evm::Call as EvmCall;
+use std::str::FromStr;
+
+fn evm_call(input: Vec<u8>) -> EvmCall<Test> {
+	let alice = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+	EvmCall::call {
+		source: alice.into(),
+		target: precompile_address(),
+		input,
+		value: U256::zero(),
+		gas_limit: u64::max_value(),
+		max_fee_per_gas: 0.into(),
+		max_priority_fee_per_gas: Some(U256::zero()),
+		nonce: None,
+		access_list: Vec::new(),
+	}
+}
+
+#[test]
+fn selectors() {
+	assert_eq!(Action::Lock as u32, 0xd8f7c836);
+	assert_eq!(Action::BurnAsset as u32, 0xe1a6d74c);
+	assert_eq!(Action::LockNft as u32, 0x6ad31c32);
+}
+
+#[test]
+fn lock_works() {
+	let alice = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+	ExtBuilder::default()
+		.with_balances(vec![(alice, 1000000000000000000000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(OctopusAppchain::force_set_is_activated(Origin::root(), true));
+
+			let amount: BalanceOf<Test> = 100000000000000000000u128.into();
+			let receiver_id: Bytes = "test.testnet".into();
+
+			let input = EvmDataWriter::new_with_selector(Action::Lock)
+				.write(amount.clone())
+				.write(receiver_id.clone())
+				.build();
+
+			assert_ok!(Call::Evm(evm_call(input)).dispatch(Origin::root()));
+		})
+}
+
+#[test]
+fn burn_asset_works() {
+	let alice = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+	ExtBuilder::default()
+		.with_balances(vec![(alice, 1000000000000000000000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(Assets::force_create(Origin::root(), 0, alice.into(), true, 1));
+
+			assert_ok!(OctopusAppchain::force_set_is_activated(Origin::root(), true));
+			assert_ok!(OctopusAppchain::mint_asset(
+				Origin::root(),
+				0,
+				"test.testnet".to_string().as_bytes().to_vec(),
+				alice.into(),
+				1000000000000000000
+			));
+
+			let asset_id: u32 = 0;
+			let amount: BalanceOf<Test> = 100000000000000000000u128.into();
+			let receiver_id: Bytes = "test.testnet".into();
+
+			let input = EvmDataWriter::new_with_selector(Action::BurnAsset)
+				.write(asset_id)
+				.write(amount.clone())
+				.write(receiver_id.clone())
+				.build();
+
+			assert_ok!(Call::Evm(evm_call(input)).dispatch(Origin::root()));
+		})
+}
+
+#[test]
+fn lock_nft_works() {
+	let alice = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+	ExtBuilder::default()
+		.with_balances(vec![(alice, 1000000000000000000000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(Assets::force_create(Origin::root(), 0, alice.into(), true, 1));
+
+			// assert_ok!(OctopusAppchain::force_set_is_activated(Origin::root(), true));
+			// assert_ok!(OctopusAppchain::mint_asset(
+			// 	Origin::root(),
+			// 	0,
+			// 	"test.testnet".to_string().as_bytes().to_vec(),
+			// 	Alice.into(),
+			// 	1000000000000000000
+			// ));
+
+			let class_id: u32 = 1;
+			let instance_id: u32 = 1;
+			let receiver_id: Bytes = "test.testnet".into();
+
+			let input = EvmDataWriter::new_with_selector(Action::LockNft)
+				.write(class_id)
+				.write(instance_id)
+				.write(receiver_id.clone())
+				.build();
+
+			assert_ok!(Call::Evm(evm_call(input)).dispatch(Origin::root()));
+		})
+}

--- a/precompiles/octopus-session/Cargo.toml
+++ b/precompiles/octopus-session/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "pallet-evm-precompile-octopus-session"
+authors = ["Octopus Network <hi@oct.network>"]
+description = "A Precompile to make pallet-session accessible to pallet-evm"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+log = "0.4"
+num_enum = { version = "0.5.3", default-features = false }
+
+# Moonbeam
+precompile-utils = { path = "../utils", default-features = false }
+
+# Substrate
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
+# Frontier
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
+# Octopus
+pallet-session = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+# pallet-session = { version = "4.0.0-dev", git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
+[dev-dependencies]
+derive_more = { version = "0.99" }
+hex-literal = "0.3.4"
+libsecp256k1 = "0.7"
+serde = { version = "1.0.100" }
+sha3 = "0.8"
+
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
+scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
+
+sp-staking = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+pallet-assets = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+pallet-uniques = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.18" }
+
+pallet-octopus-appchain = { git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
+pallet-octopus-lpos = { git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
+pallet-octopus-upward-messages = { git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
+
+account = { path = "../../primitives/account/" }
+
+[features]
+default = [ "std" ]
+std = [
+	"codec/std",
+	"fp-evm/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-evm/std",
+	"precompile-utils/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-std/std",
+	"pallet-session/std",
+]

--- a/precompiles/octopus-session/OctopusSessionInterface.sol
+++ b/precompiles/octopus-session/OctopusSessionInterface.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.8.0;
+
+/**
+ * @title Pallet Session Interface
+ *
+ * The interface through which solidity contracts will interact with pallet-session
+ * Address :    0x0000000000000000000000000000000000000804
+ */
+
+interface OctopusSession {
+    /**
+	 * set keys 
+     * Selector: 0xd8be245a
+	 *
+	 * @param keys The session key will set
+	 * @param proof The proof to set 
+	 *
+     */
+    function set_keys(bytes memory keys, bytes memory proof) external;
+}

--- a/precompiles/octopus-session/src/lib.rs
+++ b/precompiles/octopus-session/src/lib.rs
@@ -1,0 +1,109 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use fp_evm::{Context, ExitSucceed, PrecompileOutput};
+use frame_support::{
+	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+	inherent::Vec,
+};
+use pallet_evm::{AddressMapping, Precompile};
+use pallet_session::Call as OctopusSessionCall;
+use precompile_utils::{
+	Bytes, EvmDataReader, EvmResult, FunctionModifier, Gasometer, RuntimeHelper,
+};
+use sp_core::{Decode, H256};
+use sp_std::{fmt::Debug, marker::PhantomData};
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[precompile_utils::generate_function_selector]
+#[derive(Debug, PartialEq)]
+pub enum Action {
+	SetKeys = "set_keys(bytes,bytes)",
+}
+
+/// A precompile to wrap the functionality from pallet octopus-appchain.
+pub struct OctopusSessionWrapper<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> Precompile for OctopusSessionWrapper<Runtime>
+where
+	Runtime: pallet_session::Config + pallet_evm::Config + frame_system::Config,
+	<Runtime as frame_system::Config>::Call:
+		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin:
+		From<Option<Runtime::AccountId>>,
+	<Runtime as frame_system::Config>::Call: From<OctopusSessionCall<Runtime>>,
+	Runtime::Hash: From<H256>,
+{
+	fn execute(
+		input: &[u8], //Reminder this is big-endian
+		target_gas: Option<u64>,
+		context: &Context,
+		is_static: bool,
+	) -> EvmResult<PrecompileOutput> {
+		log::trace!(target: "octopus-session-precompile", "In octopus-session wrapper");
+
+		let mut gasometer = Gasometer::new(target_gas);
+		let gasometer = &mut gasometer;
+
+		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
+		let input = &mut input;
+
+		gasometer.check_function_modifier(context, is_static, FunctionModifier::NonPayable)?;
+
+		match selector {
+			// Dispatchables
+			Action::SetKeys => Self::set_keys(input, gasometer, context),
+		}
+	}
+}
+
+impl<Runtime> OctopusSessionWrapper<Runtime>
+where
+	Runtime: pallet_session::Config + pallet_evm::Config + frame_system::Config,
+	<Runtime as frame_system::Config>::Call:
+		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+	<<Runtime as frame_system::Config>::Call as Dispatchable>::Origin:
+		From<Option<Runtime::AccountId>>,
+	<Runtime as frame_system::Config>::Call: From<OctopusSessionCall<Runtime>>,
+	Runtime::Hash: From<H256>,
+{
+	// The dispatchable wrappers are next. They dispatch a Substrate inner Call.
+	fn set_keys(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		context: &Context,
+	) -> EvmResult<PrecompileOutput> {
+		input.expect_arguments(gasometer, 6)?;
+
+		// let keys: <Runtime as pallet_session::Config>::Keys = input.read(gasometer)?;
+		let keys = input.read::<Bytes>(gasometer)?;
+		let keys: Vec<u8> = keys.0;
+		let proof = input.read::<Bytes>(gasometer)?;
+		let proof: Vec<u8> = proof.0;
+
+		log::trace!(
+			target: "session-precompile",
+			"set_keys with keys {:?}, and proof {:?}",
+			keys,
+			proof,
+		);
+
+		let keys = <Runtime as pallet_session::Config>::Keys::decode(&mut keys.as_slice())
+			.map_err(|_| gasometer.revert("decode keys error"))?;
+		let origin = Runtime::AddressMapping::into_account_id(context.caller);
+		let call = OctopusSessionCall::<Runtime>::set_keys { keys, proof };
+
+		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
+
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: Default::default(),
+			logs: Default::default(),
+		})
+	}
+}

--- a/precompiles/octopus-session/src/mock.rs
+++ b/precompiles/octopus-session/src/mock.rs
@@ -1,0 +1,413 @@
+use super::*;
+use pallet_octopus_appchain::traits_default_impl::ExampleConvertor;
+use sp_runtime::{
+	generic, impl_opaque_keys,
+	testing::TestXt,
+	traits::{
+		AccountIdLookup, BlakeTwo256, ConvertInto, Extrinsic as ExtrinsicT, IdentifyAccount,
+		OpaqueKeys, Verify,
+	},
+};
+
+use pallet_evm::{EnsureAddressNever, EnsureAddressRoot, PrecompileSet};
+use sp_core::H160;
+
+pub use frame_support::{
+	construct_runtime,
+	pallet_prelude::GenesisBuild,
+	parameter_types,
+	traits::{
+		ConstU128, ConstU32, Hooks, KeyOwnerProofSystem, OnFinalize, OnInitialize, Randomness,
+		StorageInfo,
+	},
+	weights::{IdentityFee, Weight},
+	PalletId, StorageValue,
+};
+
+use account::EthereumSignature;
+use frame_system::EnsureRoot;
+
+pub(crate) type BlockNumber = u32;
+pub type Signature = EthereumSignature;
+pub type Balance = u128;
+pub type Moment = u64;
+pub type Index = u64;
+pub type Hash = sp_core::H256;
+
+pub const MILLICENTS: Balance = 10_000_000_000;
+pub const CENTS: Balance = 1_000 * MILLICENTS;
+pub const DOLLARS: Balance = 100 * CENTS;
+pub const MILLISECS_PER_BLOCK: Moment = 3000;
+pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
+pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
+pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 1 * MINUTES;
+pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
+
+parameter_types! {
+	pub const BlockHashCount: BlockNumber = 2400;
+	pub const SS58Prefix: u16 = 42;
+}
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type AccountId = AccountId;
+	type Call = Call;
+	type Lookup = AccountIdLookup<AccountId, ()>;
+	type Index = Index;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hashing = BlakeTwo256;
+	type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	type Event = Event;
+	type Origin = Origin;
+	type BlockHashCount = BlockHashCount;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: Moment = SLOT_DURATION / 2;
+}
+impl pallet_timestamp::Config for Test {
+	type Moment = Moment;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: Balance = 1 * DOLLARS;
+	pub const MaxLocks: u32 = 50;
+	pub const MaxReserves: u32 = 50;
+}
+impl pallet_balances::Config for Test {
+	type MaxLocks = MaxLocks;
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+}
+
+impl_opaque_keys! {
+	pub struct MockSessionKeys {
+		pub octopus: OctopusAppchain,
+	}
+}
+
+pub struct MockSessionManager;
+
+impl pallet_session::SessionManager<AccountId> for MockSessionManager {
+	fn end_session(_: sp_staking::SessionIndex) {}
+	fn start_session(index: sp_staking::SessionIndex) {
+		OctopusLpos::start_session(index);
+	}
+	fn new_session(_: sp_staking::SessionIndex) -> Option<Vec<AccountId>> {
+		None
+	}
+}
+
+parameter_types! {
+	pub const Period: u32 = 1;
+	pub const Offset: u32 = 0;
+}
+impl pallet_session::Config for Test {
+	type Event = Event;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
+	type ValidatorIdOf = ConvertInto;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type SessionManager = MockSessionManager;
+	type SessionHandler = <MockSessionKeys as OpaqueKeys>::KeyTypeIdProviders;
+	type Keys = MockSessionKeys;
+	type WeightInfo = pallet_session::weights::SubstrateWeight<Test>;
+}
+
+impl pallet_session::historical::Config for Test {
+	type FullIdentification = u128;
+	type FullIdentificationOf = pallet_octopus_lpos::ExposureOf<Test>;
+}
+
+pub(crate) type Extrinsic = TestXt<Call, ()>;
+pub(crate) type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+impl frame_system::offchain::SigningTypes for Test {
+	type Public = <Signature as Verify>::Signer;
+	type Signature = Signature;
+}
+
+impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
+where
+	Call: From<LocalCall>,
+{
+	type OverarchingCall = Call;
+	type Extrinsic = Extrinsic;
+}
+
+impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
+where
+	Call: From<LocalCall>,
+{
+	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+		call: Call,
+		_public: <Signature as Verify>::Signer,
+		_account: AccountId,
+		nonce: u64,
+	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+		Some((call, (nonce, ())))
+	}
+}
+
+parameter_types! {
+	pub const AssetDeposit: Balance = 100 * DOLLARS;
+	pub const ApprovalDeposit: Balance = 1 * DOLLARS;
+	pub const StringLimit: u32 = 50;
+	pub const MetadataDepositBase: Balance = 10 * DOLLARS;
+	pub const MetadataDepositPerByte: Balance = 1 * DOLLARS;
+}
+pub type AssetId = u32;
+pub type AssetBalance = u128;
+
+impl pallet_assets::Config for Test {
+	type Event = Event;
+	type Balance = AssetBalance;
+	type AssetId = AssetId;
+	type Currency = Balances;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type AssetDeposit = AssetDeposit;
+	type AssetAccountDeposit = ConstU128<DOLLARS>;
+	type MetadataDepositBase = MetadataDepositBase;
+	type MetadataDepositPerByte = MetadataDepositPerByte;
+	type ApprovalDeposit = ApprovalDeposit;
+	type StringLimit = StringLimit;
+	type Freezer = ();
+	type Extra = ();
+	type WeightInfo = pallet_assets::weights::SubstrateWeight<Test>;
+}
+
+pub struct OctopusAppCrypto;
+
+impl frame_system::offchain::AppCrypto<<Signature as Verify>::Signer, Signature>
+	for OctopusAppCrypto
+{
+	type RuntimeAppPublic = pallet_octopus_appchain::ecdsa::AuthorityId;
+	type GenericSignature = sp_core::ecdsa::Signature;
+	type GenericPublic = sp_core::ecdsa::Public;
+}
+
+parameter_types! {
+	pub const SessionsPerEra: sp_staking::SessionIndex = 6;
+	pub const BondingDuration: pallet_octopus_lpos::EraIndex = 24 * 28;
+	pub const BlocksPerEra: u32 = EPOCH_DURATION_IN_BLOCKS * 6 / (SECS_PER_BLOCK as u32);
+}
+
+impl pallet_octopus_lpos::Config for Test {
+	type Currency = Balances;
+	type UnixTime = Timestamp;
+	type Event = Event;
+	type Reward = (); // rewards are minted from the void
+	type SessionsPerEra = SessionsPerEra;
+	type BondingDuration = BondingDuration;
+	type BlocksPerEra = BlocksPerEra;
+	type SessionInterface = Self;
+	type AppchainInterface = OctopusAppchain;
+	type UpwardMessagesInterface = OctopusUpwardMessages;
+	type PalletId = OctopusAppchainPalletId;
+	type ValidatorsProvider = OctopusAppchain;
+	type WeightInfo = pallet_octopus_lpos::weights::SubstrateWeight<Test>;
+}
+
+impl pallet_octopus_upward_messages::Config for Test {
+	type Event = Event;
+	type Call = Call;
+	type UpwardMessagesLimit = UpwardMessagesLimit;
+	type WeightInfo = pallet_octopus_upward_messages::weights::SubstrateWeight<Test>;
+}
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: frame_system,
+		Timestamp: pallet_timestamp,
+		Balances: pallet_balances,
+		OctopusAppchain: pallet_octopus_appchain,
+		OctopusLpos: pallet_octopus_lpos,
+		OctopusUpwardMessages: pallet_octopus_upward_messages,
+		Session: pallet_session,
+		Assets: pallet_assets,
+		Uniques: pallet_uniques,
+		Evm: pallet_evm,
+	}
+);
+
+type ClassId = u128;
+type InstanceId = u128;
+parameter_types! {
+	pub const ClassDeposit: Balance = 100 * DOLLARS;
+	pub const InstanceDeposit: Balance = 1 * DOLLARS;
+	pub const KeyLimit: u32 = 32;
+	pub const ValueLimit: u32 = 256;
+}
+impl pallet_uniques::Config for Test {
+	type Event = Event;
+	type ClassId = ClassId;
+	type InstanceId = InstanceId;
+	type Currency = Balances;
+	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
+	type ClassDeposit = ClassDeposit;
+	type InstanceDeposit = InstanceDeposit;
+	type MetadataDepositBase = MetadataDepositBase;
+	type AttributeDepositBase = MetadataDepositBase;
+	type DepositPerByte = MetadataDepositPerByte;
+	type StringLimit = StringLimit;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	   pub const OctopusAppchainPalletId: PalletId = PalletId(*b"py/octps");
+	   pub const GracePeriod: u32 = 10;
+	   pub const UnsignedPriority: u64 = 1 << 21;
+	   pub const RequestEventLimit: u32 = 10;
+	   pub const UpwardMessagesLimit: u32 = 10;
+}
+
+impl pallet_octopus_appchain::Config for Test {
+	type AssetId = AssetId;
+	type AssetBalance = AssetBalance;
+	type AssetIdByTokenId = OctopusAppchain;
+	type AuthorityId = pallet_octopus_appchain::ecdsa::AuthorityId;
+	type AppCrypto = OctopusAppCrypto;
+	type Event = Event;
+	type Call = Call;
+	type PalletId = OctopusAppchainPalletId;
+	type LposInterface = OctopusLpos;
+	type UpwardMessagesInterface = OctopusUpwardMessages;
+	type ClassId = ClassId;
+	type InstanceId = InstanceId;
+	type Uniques = Uniques;
+	type Convertor = ExampleConvertor<Test>;
+	type Currency = Balances;
+	type Assets = Assets;
+	type GracePeriod = GracePeriod;
+	type UnsignedPriority = UnsignedPriority;
+	type RequestEventLimit = RequestEventLimit;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const PrecompilesValue: Precompiles<Test> = Precompiles(PhantomData);
+}
+
+pub struct IntoAddressMapping;
+
+impl<T: From<H160>> pallet_evm::AddressMapping<T> for IntoAddressMapping {
+	fn into_account_id(address: H160) -> T {
+		address.into()
+	}
+}
+
+impl pallet_evm::Config for Test {
+	type FeeCalculator = ();
+	type GasWeightMapping = ();
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = IntoAddressMapping;
+	type Currency = Balances;
+	type Event = Event;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = Precompiles<Self>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ();
+	type OnChargeTransaction = ();
+	type BlockGasLimit = ();
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = ();
+	type WeightInfo = ();
+}
+
+pub const PRECOMPILE_ADDRESS: u64 = 1;
+
+#[derive(Default)]
+pub struct Precompiles<R>(PhantomData<R>);
+
+impl<R> PrecompileSet for Precompiles<R>
+where
+	OctopusSessionWrapper<R>: Precompile,
+{
+	fn execute(
+		&self,
+		address: H160,
+		input: &[u8],
+		target_gas: Option<u64>,
+		context: &Context,
+		is_static: bool,
+	) -> Option<EvmResult<PrecompileOutput>> {
+		match address {
+			a if a == hash(PRECOMPILE_ADDRESS) =>
+				Some(OctopusSessionWrapper::<R>::execute(input, target_gas, context, is_static)),
+			_ => None,
+		}
+	}
+
+	fn is_precompile(&self, address: H160) -> bool {
+		address == hash(PRECOMPILE_ADDRESS)
+	}
+}
+
+fn hash(a: u64) -> H160 {
+	H160::from_low_u64_be(a)
+}
+
+pub(crate) struct ExtBuilder {
+	balances: Vec<(AccountId, Balance)>,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> ExtBuilder {
+		ExtBuilder { balances: vec![] }
+	}
+}
+
+impl ExtBuilder {
+	pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, Balance)>) -> Self {
+		self.balances = balances;
+		self
+	}
+
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.expect("Frame system builds valid default genesis config");
+
+		pallet_balances::GenesisConfig::<Test> { balances: self.balances }
+			.assimilate_storage(&mut t)
+			.expect("Pallet balances storage can be assimilated");
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}
+
+pub fn precompile_address() -> H160 {
+	H160::from_low_u64_be(1)
+}

--- a/precompiles/octopus-session/src/tests.rs
+++ b/precompiles/octopus-session/src/tests.rs
@@ -1,0 +1,48 @@
+use crate::{mock::*, *};
+
+use precompile_utils::{Bytes, EvmDataWriter};
+use sp_core::U256;
+
+use frame_support::assert_ok;
+use pallet_evm::Call as EvmCall;
+use std::str::FromStr;
+
+fn evm_call(input: Vec<u8>) -> EvmCall<Test> {
+	let alice = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+	EvmCall::call {
+		source: alice.into(),
+		target: precompile_address(),
+		input,
+		value: U256::zero(),
+		gas_limit: u64::max_value(),
+		max_fee_per_gas: 0.into(),
+		max_priority_fee_per_gas: Some(U256::zero()),
+		nonce: None,
+		access_list: Vec::new(),
+	}
+}
+
+#[test]
+fn selectors() {
+	assert_eq!(Action::SetKeys as u32, 0xd8be245a);
+}
+
+#[test]
+fn set_keys_works() {
+	let alice = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+	ExtBuilder::default()
+		.with_balances(vec![(alice, 1000000000000000000000)])
+		.build()
+		.execute_with(|| {
+			let keys: Bytes =
+				"0x03341185f68feb2bc863ebffea367571a79937d39fe8d80796df22091c563c3983".into();
+			let proof: Bytes = "test.testnet".into();
+
+			let input = EvmDataWriter::new_with_selector(Action::SetKeys)
+				.write(keys)
+				.write(proof)
+				.build();
+
+			assert_ok!(Call::Evm(evm_call(input)).dispatch(Origin::root()));
+		})
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -58,6 +58,9 @@ pallet-octopus-appchain = { default-features = false, git = "https://github.com/
 pallet-octopus-lpos = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
 pallet-octopus-upward-messages = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", branch = "release-v0.9.18" }
 
+pallet-evm-precompile-octopus-appchain = { path = "../precompiles/octopus-appchain", default-features = false }
+pallet-evm-precompile-octopus-session = { path = "../precompiles/octopus-session", default-features = false }
+
 account = { path = "../primitives/account/", default-features = false }
 pallet-evm-precompile-balances-erc20 = { path = "../precompiles/balances-erc20", default-features = false }
 precompile-utils = { path = "../precompiles/utils", default-features = false }
@@ -134,6 +137,8 @@ std = [
 	"pallet-octopus-appchain/std",
 	"pallet-octopus-lpos/std",
 	"pallet-octopus-upward-messages/std",
+	"pallet-evm-precompile-octopus-appchain/std",
+	"pallet-evm-precompile-octopus-session/std",
 
 	"account/std",
 	"pallet-evm-precompile-balances-erc20/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,14 +16,13 @@ use sp_runtime::{
 	generic::{self, Era},
 	impl_opaque_keys,
 	traits::{
-		self, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount,
-		IdentityLookup, Keccak256, NumberFor, OpaqueKeys, SaturatedConversion, StaticLookup,
-		Verify,
+		self, BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup,
+		Keccak256, NumberFor, OpaqueKeys, SaturatedConversion, StaticLookup, Verify,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
 	},
-	ApplyExtrinsicResult, MultiSignature, Perbill,
+	ApplyExtrinsicResult, Perbill,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -68,8 +67,8 @@ use pallet_ethereum::{Call::transact, Transaction as EthereumTransaction};
 #[cfg(feature = "std")]
 pub use pallet_evm::GenesisAccount;
 use pallet_evm::{
-	Account as EVMAccount, EnsureAddressNever, EnsureAddressRoot, EnsureAddressTruncated,
-	FeeCalculator, GasWeightMapping, HashedAddressMapping, Runner,
+	Account as EVMAccount, EnsureAddressNever, EnsureAddressRoot, FeeCalculator, GasWeightMapping,
+	Runner,
 };
 use precompiles::FrontierPrecompiles;
 pub type Precompiles = FrontierPrecompiles<Runtime>;
@@ -77,9 +76,8 @@ use sp_core::{ecdsa, H160, H256, U256};
 use sp_runtime::{
 	traits::{Dispatchable, PostDispatchInfoOf},
 	transaction_validity::TransactionValidityError,
-	Permill, RuntimeAppPublic,
+	Permill,
 };
-use sp_std::marker::PhantomData;
 
 /// Import the template pallet.
 pub use pallet_template;
@@ -567,6 +565,9 @@ parameter_types! {
 type ClassId = u128;
 type InstanceId = u128;
 
+parameter_types! {
+	pub const UniquesStringLimit: u32 = 2048;
+}
 impl pallet_uniques::Config<pallet_uniques::Instance1> for Runtime {
 	type Event = Event;
 	type ClassId = ClassId;
@@ -578,7 +579,7 @@ impl pallet_uniques::Config<pallet_uniques::Instance1> for Runtime {
 	type MetadataDepositBase = MetadataDepositBase;
 	type AttributeDepositBase = MetadataDepositBase;
 	type DepositPerByte = MetadataDepositPerByte;
-	type StringLimit = AssetsStringLimit;
+	type StringLimit = UniquesStringLimit;
 	type KeyLimit = KeyLimit;
 	type ValueLimit = ValueLimit;
 	type WeightInfo = pallet_uniques::weights::SubstrateWeight<Runtime>;
@@ -638,6 +639,7 @@ parameter_types! {
 	   pub const UpwardMessagesLimit: u32 = 10;
 }
 
+use pallet_octopus_appchain::traits_default_impl::RmrkBaseMetadataConvertor;
 impl pallet_octopus_appchain::Config for Runtime {
 	type AuthorityId = pallet_octopus_appchain::ecdsa::AuthorityId;
 	type AppCrypto = OctopusAppCrypto;
@@ -649,7 +651,7 @@ impl pallet_octopus_appchain::Config for Runtime {
 	type ClassId = ClassId;
 	type InstanceId = InstanceId;
 	type Uniques = OctopusUniques;
-	type Convertor = ();
+	type Convertor = RmrkBaseMetadataConvertor<Runtime>;
 	type Currency = Balances;
 	type Assets = OctopusAssets;
 	type AssetBalance = AssetBalance;
@@ -985,7 +987,7 @@ fn validate_self_contained_inner(
 		let extra_validation =
 			SignedExtra::validate_unsigned(call, &call.get_dispatch_info(), input_len)?;
 		// Then, do the controls defined by the ethereum pallet.
-		use fp_self_contained::SelfContainedCall as _;
+		// use fp_self_contained::SelfContainedCall as _;
 		let self_contained_validation = eth_call
 			.validate_self_contained(signed_info)
 			.ok_or(TransactionValidityError::Invalid(InvalidTransaction::BadProof))??;
@@ -1336,7 +1338,7 @@ impl_runtime_apis! {
 			max_priority_fee_per_gas: Option<U256>,
 			nonce: Option<U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			_access_list: Option<Vec<(H160, Vec<H256>)>>,
 		) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
 			let config = if estimate {
 				let mut config = <Runtime as pallet_evm::Config>::config().clone();
@@ -1370,7 +1372,7 @@ impl_runtime_apis! {
 			max_priority_fee_per_gas: Option<U256>,
 			nonce: Option<U256>,
 			estimate: bool,
-			access_list: Option<Vec<(H160, Vec<H256>)>>,
+			_access_list: Option<Vec<(H160, Vec<H256>)>>,
 		) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
 			let config = if estimate {
 				let mut config = <Runtime as pallet_evm::Config>::config().clone();

--- a/runtime/src/precompiles.rs
+++ b/runtime/src/precompiles.rs
@@ -7,6 +7,8 @@ use pallet_evm_precompile_blake2::Blake2F;
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
+use pallet_evm_precompile_octopus_appchain::OctopusAppchainWrapper;
+use pallet_evm_precompile_octopus_session::OctopusSessionWrapper;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
 
@@ -67,6 +69,8 @@ impl<R> PrecompileSet for FrontierPrecompiles<R>
 where
 	Dispatch<R>: Precompile,
 	Erc20BalancesPrecompile<R, NativeErc20Metadata>: Precompile,
+	OctopusAppchainWrapper<R>: Precompile,
+	OctopusSessionWrapper<R>: Precompile,
 	R: pallet_evm::Config,
 {
 	fn execute(
@@ -99,6 +103,10 @@ where
 				Some(Erc20BalancesPrecompile::<R, NativeErc20Metadata>::execute(
 					input, target_gas, context, is_static,
 				)),
+			a if a == hash(2051) =>
+				Some(OctopusAppchainWrapper::<R>::execute(input, target_gas, context, is_static)),
+			a if a == hash(2052) =>
+				Some(OctopusSessionWrapper::<R>::execute(input, target_gas, context, is_static)),
 			_ => None,
 		}
 	}


### PR DESCRIPTION
This PR add two precompiles to support cross chain:
-   Precompile OctopusAppchain to support ```lock```  \ ```burn_asset``` \ ```lock_nft``` ;
-   Precompile OctopusSession to support set session key.  