### PR TITLE
Update benchmarking for pallets

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -75,6 +75,7 @@ pallet-octopus-upward-messages = { default-features = false, git = "https://gith
 
 # + benchmarking
 pallet-octopus-appchain-benchmarking = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", branch = "main", optional = true }
+pallet-octopus-bridge-benchmarking = { default-features = false, git = "https://github.com/octopus-network/octopus-pallets.git", branch = "main", optional = true }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
@@ -140,6 +141,7 @@ runtime-benchmarks = [
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"pallet-octopus-appchain-benchmarking",
+	"pallet-octopus-bridge-benchmarking",
 	"pallet-uniques/runtime-benchmarks",
 	"pallet-octopus-lpos/runtime-benchmarks",
 	"pallet-octopus-upward-messages/runtime-benchmarks",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -781,6 +781,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_octopus_upward_messages, OctopusUpwardMessages]
 		[pallet_octopus_appchain, AppchainBench::<Runtime>]
+		[pallet_octopus_bridge, BridgeBench::<Runtime>]
 		[pallet_octopus_lpos, OctopusLpos]
 	);
 }
@@ -1072,6 +1073,7 @@ impl_runtime_apis! {
 			use frame_system_benchmarking::Pallet as SystemBench;
 			use baseline::Pallet as BaselineBench;
 			use pallet_octopus_appchain_benchmarking::Pallet as AppchainBench;
+			use pallet_octopus_bridge_benchmarking::Pallet as BridgeBench;
 
 			let mut list = Vec::<BenchmarkList>::new();
 			list_benchmarks!(list, extra);
@@ -1089,10 +1091,12 @@ impl_runtime_apis! {
 			use frame_system_benchmarking::Pallet as SystemBench;
 			use baseline::Pallet as BaselineBench;
 			use pallet_octopus_appchain_benchmarking::Pallet as AppchainBench;
+			use pallet_octopus_bridge_benchmarking::Pallet as BridgeBench;
 
 			impl frame_system_benchmarking::Config for Runtime {}
 			impl baseline::Config for Runtime {}
 			impl pallet_octopus_appchain_benchmarking::Config for Runtime {}
+			impl pallet_octopus_bridge_benchmarking::Config for Runtime {}
 
 			let whitelist: Vec<TrackedStorageKey> = vec![
 				// Block Number


### PR DESCRIPTION
Update benchmarking for pallets:

1. Update benchmarking for appchain and upward-messages 
2. Add benchmarking for bridge